### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/entries.js
+++ b/lib/entries.js
@@ -3,7 +3,7 @@
   var ref$, memoize, localIsoTime, getYesterday, yaml, yamlDump, deltosHome, BASEDIR, getFilename, tagged, getSlug, fs, uuid, filter, values, sortBy, reverse, newNote, dumpTodos, renderTsvEntry, dumpTsv, dumpTsvTagged, dumpTsvCore, grepEntries, philtreEntries, readEntry, getAllEntries, getRawEntry, getEntryParts, getNewId, newDaily, out$ = typeof exports != 'undefined' && exports || this, slice$ = [].slice;
   ref$ = require('./util'), memoize = ref$.memoize, localIsoTime = ref$.localIsoTime, getYesterday = ref$.getYesterday, yaml = ref$.yaml, yamlDump = ref$.yamlDump, deltosHome = ref$.deltosHome, BASEDIR = ref$.BASEDIR, getFilename = ref$.getFilename, tagged = ref$.tagged, getSlug = ref$.getSlug;
   fs = require('fs');
-  uuid = require('node-uuid');
+  uuid = require('uuid');
   ref$ = require('prelude-ls'), filter = ref$.filter, values = ref$.values, sortBy = ref$.sortBy, reverse = ref$.reverse;
   out$.newNote = newNote = function(title, tags, metadata){
     var base, key, fname;

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   "bugs": "http://github.com/polm/deltos/issues",
   "license": "WTFPL",
   "dependencies": {
+    "domino": "^1.0.19",
     "js-yaml": "^3.2.2",
     "markdown-it": "^6.0.0",
-    "node-uuid": "^1.4.1",
-    "prelude-ls": "^1.1.1",
-    "domino": "^1.0.19",
-    "rss": "^1.0.0",
     "mkdirp": "^0.5.1",
+    "philtre": "^0.0.7",
+    "prelude-ls": "^1.1.1",
+    "rss": "^1.0.0",
     "searchy": "^0.0.19",
-    "philtre": "^0.0.7"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "livescript": "^1.4.0"

--- a/package.json.ls
+++ b/package.json.ls
@@ -17,7 +17,7 @@ license: \WTFPL
 dependencies:
   'js-yaml': \^3.2.2
   'markdown-it': \^6.0.0
-  'node-uuid': \^1.4.1
+  'uuid': \^3.0.0
   'prelude-ls': \^1.1.1
   domino: \^1.0.19
   rss: \^1.0.0

--- a/src/entries.ls
+++ b/src/entries.ls
@@ -1,7 +1,7 @@
 {memoize, local-iso-time, get-yesterday, yaml, yaml-dump, \
  deltos-home, BASEDIR, get-filename, tagged, get-slug} = require \./util
 fs = require \fs
-uuid = require \node-uuid
+uuid = require \uuid
 {filter, values, sort-by, reverse} = require \prelude-ls
 
 export new-note = (title="", tags=[], metadata={}) ->


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.